### PR TITLE
Update landing page info text and hide event carousel

### DIFF
--- a/src/components/Info.js
+++ b/src/components/Info.js
@@ -6,14 +6,19 @@ const Info = () => {
   return (
     <div>
       <div className="vogel-mobile">
-        <img class="vogel" src={vogel} alt="Vogel"></img>
+        <img className="vogel" src={vogel} alt="Vogel" />
       </div>
       <div className="beschreibung">
         <div>
-        Under Construction: Der MoaFinder wird größer und besser. Wir sind große Fans von unserem Kiez und allem was hier passiert. Das wollen wir noch besser sichtbar machen. Ab September 2026 findet ihr hier den neuen MoaFinder.
+          Under Construction: Der MoaFinder wird größer und besser. Wir sind große
+          Fans von unserem Kiez und allem was hier passiert. Das wollen wir noch
+          besser sichtbar machen. Ab November 2025 findet ihr hier den neuen
+          MoaFinder.
         </div>
         <div>
-        Moabit.World wird eine interaktive Vernetzungsplattform für unseren Kiez. Hier findet ihr in Zukunft Informationen zu Kampagnen, Aktionen und Mitmachformaten in unserem Kiez. 
+          Moabit.World wird eine interaktive Vernetzungsplattform für unseren
+          Kiez. Hier findet ihr in Zukunft Informationen zu Kampagnen, Aktionen
+          und Mitmachformaten in unserem Kiez.
         </div>
       </div>
       <div>

--- a/src/components/LandingPageContainer.js
+++ b/src/components/LandingPageContainer.js
@@ -5,7 +5,6 @@ import Links from "./Links";
 import Angebote from "./Angebote";
 import Host from "./Host";
 import Footer from "./Footer";
-import EventCarousel from "./EventCarousel";
 import Enemies from "./Enemies";
 import Bar from "./Bar";
 import Veranstaltung from "./Veranstaltung";
@@ -31,7 +30,7 @@ const LandingPageContainer = () => {
       <LandingPage />
 
       <Info />
-      <EventCarousel />
+      {/* Temporarily hidden carousel */}
       <Angebote />
       <Veranstaltung />
 


### PR DESCRIPTION
## Summary
- update the landing page intro copy to announce the November 2025 relaunch of the MoaFinder
- temporarily hide the event carousel so visitors see the engagement section directly under the intro text

## Testing
- npm test -- --watchAll=false *(fails: existing Jest setup cannot parse axios' ESM entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68d0406b74088326932e366db8429a90